### PR TITLE
geo location api changed and some test case of event filter fixed

### DIFF
--- a/practice-app/back-end/src/api/routes/events.js
+++ b/practice-app/back-end/src/api/routes/events.js
@@ -15,13 +15,23 @@ eventsRoute.get('/search', async (req, res) => {
 });
 
 eventsRoute.get('/filter', async (req, res) => {
-  const { radius, place } = req.query;
+  const { radius,place,limit } = req.query;
+
 
   const location = await getLocation(place);
-  // Get 30 events within given place around radius.
-  const conferences = await filterConferences(radius, location, 30);
 
+  let conferences;
+  if (limit === undefined) {
+    // default limit size 30
+    conferences = await filterConferences(radius, location, 30);
+  } else {
+    conferences = await filterConferences(radius, location, limit);
+  }
+ 
+ 
+  // Get 30 events with default limit or events as much as given limit.
   res.status(200).send(conferences);
+
 });
 
 

--- a/practice-app/back-end/src/services/eventService.js
+++ b/practice-app/back-end/src/services/eventService.js
@@ -3,36 +3,35 @@ import config from '../config';
 
 const API_KEY = config.predict_api_key;
 
-export const filterConferences = async (radius, location, limit) => {
+export const filterConferences = async (radius,location,limit) => {
   const list = [];
   let params = '';
   let ll = '';
-  if (location != null) {
-    ll = location.replace(' ', ',');
+  if (location != null){
+    ll = `${location.lat},${location.lng}`;
     params = `?label.op=any&label=conference,science,career,education,technology&within=${radius}km@${ll}&limit=${limit}`;
-  } else {
-    params = `?label.op=any&label=conference,science,career,education,technology&limit=${limit}`;
-  }
-  const response = await fetch(`https://api.predicthq.com/v1/events/${params}`, {
-    method: 'get',
-    headers: {
-      Authorization: `Bearer ${API_KEY}`,
-      Accept: 'application/json',
-    },
-  });
-  const json = await response.json();
-  json.results.forEach((result) => {
-    list.push({
-      title: result.title,
-      description: result.description,
-      labels: result.labels,
-      start: result.start,
-      end: result.end,
-      country: result.country,
-      state: result.state,
-      address: result.entities[0],
+    const response = await fetch(`https://api.predicthq.com/v1/events/${params}`, { 
+      method:'get',
+      headers: {
+        Authorization: `Bearer ${API_KEY}`,
+        Accept: 'application/json',
+      },
     });
-  });
+    const json = await response.json();
+    json.results.forEach((result) => {
+      list.push({
+        title: result.title,
+        description: result.description,
+        labels: result.labels,
+        start: result.start,
+        end: result.end,
+        country: result.country,
+        state: result.state,
+        address: result.entities[0],
+      });
+    });
+  }
+  
   return {
     count: list.length,
     conferences: list,

--- a/practice-app/back-end/src/services/geoLocation.js
+++ b/practice-app/back-end/src/services/geoLocation.js
@@ -1,30 +1,36 @@
+import config from '../config';
 const fetch = require('isomorphic-unfetch');
-const config = require('../config');
+
+const API_KEY = config.geo_location;
 
 
-export const getLocation = async (location) => {
-  const url = `https://devru-latitude-longitude-find-v1.p.rapidapi.com/latlon.php?location=${location}`;
-  const options = {
+export const getLocation = async (place) => {
+  
+  if (place === undefined) {
+    return null;
+  }
+
+  const url = `https://api.opencagedata.com/geocode/v1/json?q=${place}&key=${API_KEY}`;
+  const ll = await fetch(url, {
     method: 'GET',
     headers: {
-      'x-rapidapi-host': 'devru-latitude-longitude-find-v1.p.rapidapi.com',
-      'x-rapidapi-key': config.default.geo_location,
-      Accept: 'application/json',
+      'content-type': 'application/json',
     },
-  };
-  const ll = await fetch(url, options).then((response) => {
+  }).then((response) => {
     if (response.status >= 400) {
-      throw new Error('Bad response from server');
+      throw new Error("Bad response from server");
     }
     return response.json().then((res) => {
       // If location is not found, return null
-      if (res.Results.length === 0) {
+      
+      if (res.results.length == 0) {
         return null;
+      } else {
+        // Returns first location's latitude and longitude
+        return res.results[0].geometry;
       }
-      // Returns first location's latitude and longitude
-      return res.Results[0].ll;
     });
   });
 
   return ll;
-};
+}

--- a/practice-app/back-end/test/events.test.js
+++ b/practice-app/back-end/test/events.test.js
@@ -16,7 +16,8 @@ describe('GET /events/filter with no parameters', () => {
     const response = await request(app)
       .get('/api/events/filter')
       .expect(200);
-    expect(response.body.count).to.greaterThan(0);
+    expect(response.body.count).to.equal(0);
+    expect(response.body.conferences).to.have.length(0);
   });
 });
 
@@ -38,6 +39,7 @@ describe('GET /events/filter with some paramaters', () => {
   });
 });
 
+// CHANGE LAST TWO TEST CASE.
 describe('/GET geoLocation service with place parameter', () => {
   it('should respond with null', async () => {
     const response = await getLocation('aplacethatisnotintheworld');
@@ -45,8 +47,8 @@ describe('/GET geoLocation service with place parameter', () => {
   });
   it('should respond with lattitude and longitutude', async () => {
     const response = await getLocation('Istanbul');
-    const result = response.split(' ').map(Number);
-    expect(result).to.deep.equal([41.009998, 28.950001]);
+    const result = [response.lat,response.lng];
+    expect(result).to.deep.equal([41.0096334, 28.9651646]);
   });
 });
 


### PR DESCRIPTION
## I did some modifications for event filter end-point
 - [x] I changed old geolocation API and we are using ![OpenCage Geocoding API](https://opencagedata.com/api#forward-opt) now.
 - [x] I added a limit parameter which is the maximum number of events we should return. The default is 30.
- [x] If no filter parameters are given, no events can be shown.
- [x] If an unknown location is given, no events can be shown.

