### PR TITLE
Fixed bug in permissions

### DIFF
--- a/backend/api/permission.py
+++ b/backend/api/permission.py
@@ -42,7 +42,7 @@ class IsRequestSenderOrReceiver(permissions.BasePermission):
         # so we'll always allow GET, HEAD or OPTIONS requests.
         if request.method in permissions.SAFE_METHODS:
             return request.user.id == obj.req_from_user.id \
-                   or request.user.id == obj.req_to_user.id
+                or request.user.id == obj.req_to_user.id
 
         # Write permissions are only allowed to the members of the snippet.
         return request.user.id == obj.req_from_user
@@ -90,10 +90,10 @@ class CollaborationPermissions(permissions.BasePermission):
 
     def has_object_permission(self, request, view, obj):
         if view.action in ['retrieve', 'list']:
-            return request.user == obj.req_to_user or \
-                   request.user == obj.req_from_user
+            return request.user == obj.to_user or \
+                request.user == obj.from_user
         elif view.action in ['update', 'partial_update', 'destroy']:
-            return request.user == obj.req_from_user
+            return request.user == obj.from_user
         return True
 
 

--- a/backend/backend/tests/test_collaboration_invite.py
+++ b/backend/backend/tests/test_collaboration_invite.py
@@ -53,6 +53,29 @@ class CollaborationInviteTests(APITestCase):
             {'to_user__id': self.invited_user.id})
         self.assertEqual(response.content.decode('utf-8'), '[]')
 
+    def test_can_delete_collaboration_invite(self):
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.post('/api/collaboration_invites/',
+                                    {'to_project': self.project.id,
+                                     'to_user': self.invited_user.id},
+                                    format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.client.force_authenticate(user=self.invited_user)
+        response = self.client.get(
+            '/api/collaboration_invites/',
+            {'to_user__id': self.invited_user.id})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertNotEqual(response.content.decode('utf-8'), '[]')
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.delete(
+            '/api/collaboration_invites/1/')
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.client.force_authenticate(user=self.invited_user)
+        response = self.client.get(
+            '/api/collaboration_invites/',
+            {'to_user__id': self.invited_user.id})
+        self.assertEqual(response.content.decode('utf-8'), '[]')
+
     def test_can_not_invite_self(self):
         self.client.force_authenticate(user=self.owner)
         response = self.client.post('/api/collaboration_invites/',


### PR DESCRIPTION
The problem of delete in collaboration invite was caused by an error in permissions. The permissions were modified and a est case was added to cover this functionality.