### PR TITLE
Implemented filters for search

### DIFF
--- a/backend/api/serializers/search.py
+++ b/backend/api/serializers/search.py
@@ -2,10 +2,40 @@ from rest_framework import serializers
 from api.serializers.event import EventSerializer
 from api.serializers.project import ProjectGETPublicSerializer
 from api.serializers.profile import ProfileBasicSerializer
+from api.models.event import TYPE_CHOICES
+from api.models.project import STATE_CHOICES
+
+SEARCH_TYPES = ["all", "project", "profile", "event"]
+SEARCH_TYPE_CHOICES = [(SEARCH_TYPES[i], str(i))
+                       for i in range(len(SEARCH_TYPES))]
 
 
-class SearchSerializer(serializers.Serializer):
+class SearchRequestSerializer(serializers.Serializer):
     keyword = serializers.CharField(min_length=3)
+    search_type = serializers.ChoiceField(
+        choices=SEARCH_TYPE_CHOICES, allow_null=True, required=False,
+        default="all")
+
+    profile_affiliations = serializers.CharField(allow_null=True,
+                                                 required=False)
+    profile_expertise = serializers.CharField(allow_null=True, required=False)
+
+    event_date_after = serializers.DateField(allow_null=True, required=False)
+    event_date_before = serializers.DateField(allow_null=True, required=False)
+    event_deadline_after = serializers.DateField(
+        allow_null=True, required=False)
+    event_deadline_before = serializers.DateField(
+        allow_null=True, required=False)
+    event_type = serializers.ChoiceField(
+        choices=TYPE_CHOICES, allow_null=True, required=False)
+
+    project_due_date_after = serializers.DateField(
+        allow_null=True, required=False)
+    project_due_date_before = serializers.DateField(
+        allow_null=True, required=False)
+    project_event = serializers.IntegerField(allow_null=True, required=False)
+    project_state = serializers.ChoiceField(
+        choices=STATE_CHOICES, allow_null=True, required=False)
 
 
 class SearchResponseSerializer(serializers.Serializer):

--- a/backend/api/views/search.py
+++ b/backend/api/views/search.py
@@ -5,7 +5,7 @@ from api.models.event import Event
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework import generics
-from api.serializers.search import SearchSerializer
+from api.serializers.search import SearchRequestSerializer
 from api.serializers.event import EventSerializer
 from api.serializers.project import ProjectGETPublicSerializer
 from api.serializers.project import ProjectPrivateSerializer
@@ -20,19 +20,24 @@ class SearchGenericAPIView(generics.GenericAPIView):
     """
         Execute a search with a string
     """
-    serializer_class = SearchSerializer
+    serializer_class = SearchRequestSerializer
 
     def post(self, request: Request, *args, **kwargs):
         serializer = self.serializer_class(data=request.data)
         serializer.is_valid(raise_exception=True)
-        keyword_req = serializer.validated_data['keyword']
+
+        req_data = serializer.validated_data
+
+        keyword_req = req_data['keyword']
+        search_type = req_data['search_type']
+
         api = datamuse.Datamuse()
         keyword_list = api.words(rel_jja=keyword_req, max=5)
         keywords = [keyword_req]
         for keyword_dict in keyword_list:
             keywords.append(keyword_dict['word'])
 
-        res = {'events': [], 'projects': [], 'profiles': []}
+        res = {}
 
         query_events = []
         query_profiles = []
@@ -42,6 +47,17 @@ class SearchGenericAPIView(generics.GenericAPIView):
         query_private_projects = []
 
         isGuest = isinstance(request.user, AnonymousUser)
+        search_projects = search_type in ["all", "project"]
+        search_profiles = search_type in ["all", "profile"]
+        search_events = search_type in ["all", "event"]
+
+        any_project_filter = len(set(["project_due_date_after",
+                                      "project_due_date_before",
+                                      "project_event", "project_state"])
+                                 .intersection(set(req_data.keys()))) > 0
+        any_profile_filter = len(set(["profile_affiliations",
+                                      "profile_expertise"])
+                                 .intersection(set(req_data.keys()))) > 0
 
         query_following = []
         if not isGuest:
@@ -50,110 +66,149 @@ class SearchGenericAPIView(generics.GenericAPIView):
                                        filter(from_user=request.user)))
 
         for keyword in keywords:
-            query_events += Event.objects.filter(
-                Q(title__icontains=keyword) |
-                Q(description__icontains=keyword)
-            )
+            if search_events:
+                q = Q(title__icontains=keyword) | Q(
+                    description__icontains=keyword)
 
-            if isGuest:
-                query_projects += Project.objects.filter(
-                    Q(is_public=True) &
-                    (Q(name__icontains=keyword) |
-                     Q(description__icontains=keyword) |
-                        Q(project_type__icontains=keyword) |
-                        Q(event__title__icontains=keyword) |
-                        Q(event__description__icontains=keyword))
-                )
-                query_private_projects += Project.objects.filter(
-                    Q(is_public=False) &
-                    (Q(name__icontains=keyword) |
-                     Q(description__icontains=keyword))
-                )
-                query_profiles += Profile.objects.filter(
-                    Q(is_public=True) &
-                    (Q(name__icontains=keyword) |
-                     Q(middle_name__icontains=keyword) |
-                     Q(last_name__icontains=keyword) |
-                     Q(expertise__icontains=keyword) |
-                     Q(interests__icontains=keyword) |
-                     (Q(share_bio=True) & Q(bio__icontains=keyword)) |
-                     (Q(share_affiliations=True) &
-                      Q(affiliations__icontains=keyword)))
-                )
-                query_private_profiles += Profile.objects.filter(
-                    Q(is_public=False) &
-                    (Q(name__icontains=keyword) |
-                     Q(middle_name__icontains=keyword) |
-                     Q(last_name__icontains=keyword))
-                )
-            else:
-                query_projects += Project.objects.filter(
-                    (Q(is_public=True) | Q(members__id=request.user.id)) &
-                    (Q(name__icontains=keyword) |
-                     Q(description__icontains=keyword) |
-                     Q(project_type__icontains=keyword) |
-                     Q(event__title__icontains=keyword) |
-                     Q(event__description__icontains=keyword))
-                )
-                query_private_projects += Project.objects.filter(
-                    (Q(is_public=False) & ~Q(members__id=request.user.id)) &
-                    (Q(name__icontains=keyword) |
-                     Q(description__icontains=keyword))
-                )
+                if "event_date_after" in req_data:
+                    q &= Q(date__gte=req_data["event_date_after"])
+                if "event_date_before" in req_data:
+                    q &= Q(date__lte=req_data["event_date_before"])
+                if "event_deadline_after" in req_data:
+                    q &= Q(deadline__gte=req_data["event_deadline_after"])
+                if "event_deadline_before" in req_data:
+                    q &= Q(deadline__lte=req_data["event_deadline_before"])
+                if "event_type" in req_data:
+                    q &= Q(event_type=req_data["event_type"])
 
-                query_profiles += Profile.objects.filter(
-                    Q(is_public=True) &
-                    (Q(name__icontains=keyword) |
-                     Q(middle_name__icontains=keyword) |
-                     Q(last_name__icontains=keyword) |
-                     Q(expertise__icontains=keyword) |
-                     Q(interests__icontains=keyword) |
-                     (Q(share_bio=True) & Q(bio__icontains=keyword)) |
-                     (Q(share_affiliations=True) &
-                      Q(affiliations__icontains=keyword)))
-                )
-                query_followed_profiles += Profile.objects.filter(
-                    (Q(is_public=False) & Q(owner__in=query_following)) &
-                    (Q(name__icontains=keyword) |
-                     Q(middle_name__icontains=keyword) |
-                     Q(last_name__icontains=keyword) |
-                     Q(expertise__icontains=keyword) |
-                     Q(interests__icontains=keyword) |
-                     (Q(share_bio=True) & Q(bio__icontains=keyword)) |
-                     (Q(share_affiliations=True) &
-                      Q(affiliations__icontains=keyword)))
-                )
-                query_private_profiles += Profile.objects.filter(
-                    (Q(is_public=False) & ~Q(owner__in=query_following)) &
-                    (Q(name__icontains=keyword) |
-                     Q(middle_name__icontains=keyword) |
-                     Q(last_name__icontains=keyword))
-                )
+                query_events += Event.objects.filter(q)
 
-        query_events = list(set(query_events))
-        query_profiles = list(set(query_profiles))
-        query_followed_profiles = list(set(query_followed_profiles))
-        query_private_profiles = list(set(query_private_profiles))
-        query_projects = list(set(query_projects))
-        query_private_projects = list(set(query_private_projects))
+            if search_projects:
+                q = Q()
 
-        event_serializer = EventSerializer(query_events, many=True)
+                if isGuest:
+                    q = Q(is_public=True)
+                else:
+                    q = (Q(is_public=True) | Q(
+                        members__id=request.user.id))
 
-        project_serializer = ProjectGETPublicSerializer(
-            query_projects, many=True)
-        private_project_serializer = ProjectPrivateSerializer(
-            query_private_projects, many=True)
+                if "project_due_date_after" in req_data:
+                    q &= Q(due_date__gte=req_data["project_due_date_after"])
+                if "project_due_date_before" in req_data:
+                    q &= Q(due_date__lte=req_data["project_due_date_before"])
+                if "project_event" in req_data:
+                    q &= Q(event__id=req_data["project_event"])
+                if "project_state" in req_data:
+                    q &= Q(state=req_data["project_state"])
 
-        profile_serializer = ProfileBasicSerializer(query_profiles, many=True)
-        followed_profile_serializer = ProfileBasicSerializer(
-            query_followed_profiles, many=True)
-        private_profile_serializer = ProfilePrivateSerializer(
-            query_private_profiles, many=True)
+                q &= (Q(name__icontains=keyword) |
+                      Q(description__icontains=keyword) |
+                      Q(project_type__icontains=keyword) |
+                      Q(event__title__icontains=keyword) |
+                      Q(event__description__icontains=keyword))
 
-        res['events'] = event_serializer.data
-        res['projects'] = project_serializer.data + \
-            private_project_serializer.data
-        res['profiles'] = profile_serializer.data + \
-            followed_profile_serializer.data + private_profile_serializer.data
+                query_projects += Project.objects.filter(q)
+
+                if not any_project_filter:
+                    q = Q()
+                    if isGuest:
+                        q = Q(is_public=False)
+                    else:
+                        q = (Q(is_public=False) & ~Q(
+                            members__id=request.user.id))
+                    q &= (Q(name__icontains=keyword) |
+                          Q(description__icontains=keyword))
+
+                    query_private_projects += Project.objects.filter(q)
+
+            if search_profiles:
+                q = Q(is_public=True)
+                q &= (Q(name__icontains=keyword) |
+                      Q(middle_name__icontains=keyword) |
+                      Q(last_name__icontains=keyword) |
+                      Q(expertise__icontains=keyword) |
+                      Q(interests__icontains=keyword) |
+                      (Q(share_bio=True) & Q(bio__icontains=keyword)) |
+                      (Q(share_affiliations=True) &
+                       Q(affiliations__icontains=keyword)))
+
+                if "profile_affiliations" in req_data:
+                    q &= Q(
+                        affiliations__icontains=req_data[
+                            "profile_affiliations"])
+                if "profile_expertise" in req_data:
+                    q &= Q(expertise__icontains=req_data["profile_expertise"])
+
+                query_profiles += Profile.objects.filter(q)
+
+                if not isGuest:
+                    q = (Q(is_public=False) & Q(owner__in=query_following))
+
+                    q &= (Q(name__icontains=keyword) |
+                          Q(middle_name__icontains=keyword) |
+                          Q(last_name__icontains=keyword) |
+                          Q(expertise__icontains=keyword) |
+                          Q(interests__icontains=keyword) |
+                          (Q(share_bio=True) & Q(bio__icontains=keyword)) |
+                          (Q(share_affiliations=True) &
+                           Q(affiliations__icontains=keyword)))
+
+                    if "profile_affiliations" in req_data:
+                        q &= Q(
+                            affiliations__icontains=req_data[
+                                "profile_affiliations"])
+                    if "profile_expertise" in req_data:
+                        q &= Q(
+                            expertise__icontains=req_data["profile_expertise"])
+
+                    query_followed_profiles += Profile.objects.filter(q)
+
+                if not any_profile_filter:
+                    q = Q()
+                    if isGuest:
+                        q = Q(is_public=False)
+                    else:
+                        q = (Q(is_public=False) & ~Q(
+                            owner__in=query_following))
+                    q &= (Q(name__icontains=keyword) |
+                          Q(middle_name__icontains=keyword) |
+                          Q(last_name__icontains=keyword))
+
+                    query_private_profiles += Profile.objects.filter(q)
+
+        if search_events:
+            query_events = list(set(query_events))
+
+            event_serializer = EventSerializer(query_events, many=True)
+
+            res['events'] = event_serializer.data
+
+        if search_projects:
+            query_projects = list(set(query_projects))
+            query_private_projects = list(set(query_private_projects))
+
+            project_serializer = ProjectGETPublicSerializer(
+                query_projects, many=True)
+            private_project_serializer = ProjectPrivateSerializer(
+                query_private_projects, many=True)
+
+            res['projects'] = project_serializer.data + \
+                private_project_serializer.data
+
+        if search_profiles:
+            query_profiles = list(set(query_profiles))
+            query_followed_profiles = list(set(query_followed_profiles))
+            query_private_profiles = list(set(query_private_profiles))
+
+            profile_serializer = ProfileBasicSerializer(
+                query_profiles, many=True)
+            followed_profile_serializer = ProfileBasicSerializer(
+                query_followed_profiles, many=True)
+            private_profile_serializer = ProfilePrivateSerializer(
+                query_private_profiles, many=True)
+
+            res['profiles'] = profile_serializer.data + \
+                followed_profile_serializer.data + \
+                private_profile_serializer.data
 
         return Response(data=res)


### PR DESCRIPTION
I implemented filters mentioned for search in requirements. If you want to use a filter, just enter a value for that field.

- "search_type": can be "all", "project", "profile", or "event". The default is all.
- "profile_affiliations", and "profile_expertise": checks if the given values are included(case-insensitive) in profiles.
- "event_date_after", "event_date_before", "event_deadline_after", "event_deadline_before": accepts date and filters events accordingly.
- "event_type": matches the given value to event types and filters.
- "project_due_date_after", and "project_due_date_before": accepts date and filters projects accordingly.
- "project_event": accepts integer and filters project where the id of the linked event is equal to it.
- "project_state": matches the given value to project states and filters.