### PR TITLE
Backend - Fix unfollow logic

### DIFF
--- a/backend/api/views/following.py
+++ b/backend/api/views/following.py
@@ -43,7 +43,7 @@ class FollowingViewSet(viewsets.ModelViewSet):
 
         following = get_object_or_404(
             Following, pk=pk)
-        if following.to_user == self.request.user:
+        if following.from_user == self.request.user:
             following.unfollow()
             return Response(status=status.HTTP_201_CREATED)
         else:


### PR DESCRIPTION
For a follow object, "from_user" should be able to make the unfollow operation.

If A follows B, A should be able to break this follow relation and send unfollow request.