### PR TITLE
Fixed search errors

### DIFF
--- a/backend/api/serializers/search.py
+++ b/backend/api/serializers/search.py
@@ -11,7 +11,7 @@ SEARCH_TYPE_CHOICES = [(SEARCH_TYPES[i], str(i))
 
 
 class SearchRequestSerializer(serializers.Serializer):
-    keyword = serializers.CharField(min_length=3)
+    keyword = serializers.CharField(min_length=2)
     search_type = serializers.ChoiceField(
         choices=SEARCH_TYPE_CHOICES, allow_null=True, required=False,
         default="all")

--- a/backend/api/views/search.py
+++ b/backend/api/views/search.py
@@ -188,7 +188,8 @@ class SearchGenericAPIView(generics.GenericAPIView):
             query_private_projects = list(set(query_private_projects))
 
             project_serializer = ProjectGETPublicSerializer(
-                query_projects, many=True)
+                query_projects, many=True,
+                context={'request': request})
             private_project_serializer = ProjectPrivateSerializer(
                 query_private_projects, many=True)
 


### PR DESCRIPTION
 - Fixed parts that cause errors by passing the context with the ProjecGETPublicSerializer.
 - Also reduced the min keyword length for the search to 2.

**Details of the problem is in the linked issue.**