### PR TITLE
Error Correction on Collaboration Request

### DIFF
--- a/android/app/src/main/java/com/bounswe2020group3/paperlayer/home/adaptors/ProjectAdaptor.kt
+++ b/android/app/src/main/java/com/bounswe2020group3/paperlayer/home/adaptors/ProjectAdaptor.kt
@@ -62,8 +62,10 @@ class ProjectAdaptor (var clickListener: OnCardClickListener) : RecyclerView.Ada
                     action.onCollabButtonClick(item, adapterPosition)
                 }
             }
-            else if(item.projectState !="open for collaborators" )
+            else if(item.projectState !="open for collaborators" ) {
                 buttonCollab.text = "Not looking for new collaborators"
+                buttonCollab.visibility = View.GONE
+            }
             else {
                 buttonCollab.text = "Collaborate"
 


### PR DESCRIPTION
I have deleted the collaboration button for the projects which are not looking for collaborators to prevent the bug which mistakenly enables the user to send collaboration request to the projects that he is not supposed to be able to.