### PR TITLE
Aded filter with project tag functionality to search

### DIFF
--- a/backend/api/admin.py
+++ b/backend/api/admin.py
@@ -11,6 +11,7 @@ from .models.collaboration_invite import CollaborationInvite
 from .models.collaboration_request import CollaborationRequest
 from .models.comment import Comment
 from .models.rating import Rating
+from .models.tag import Tag
 
 admin.site.register(Example)
 admin.site.register(Profile)
@@ -23,3 +24,4 @@ admin.site.register(CollaborationInvite)
 admin.site.register(CollaborationRequest)
 admin.site.register(Comment)
 admin.site.register(Rating)
+admin.site.register(Tag)

--- a/backend/api/serializers/search.py
+++ b/backend/api/serializers/search.py
@@ -15,6 +15,8 @@ class SearchRequestSerializer(serializers.Serializer):
     search_type = serializers.ChoiceField(
         choices=SEARCH_TYPE_CHOICES, allow_null=True, required=False,
         default="all")
+    tags = serializers.ListField(
+        child=serializers.IntegerField(), allow_null=True, required=False)
 
     profile_affiliations = serializers.CharField(allow_null=True,
                                                  required=False)

--- a/backend/api/serializers/search.py
+++ b/backend/api/serializers/search.py
@@ -15,8 +15,6 @@ class SearchRequestSerializer(serializers.Serializer):
     search_type = serializers.ChoiceField(
         choices=SEARCH_TYPE_CHOICES, allow_null=True, required=False,
         default="all")
-    tags = serializers.ListField(
-        child=serializers.IntegerField(), allow_null=True, required=False)
 
     profile_affiliations = serializers.CharField(allow_null=True,
                                                  required=False)
@@ -38,6 +36,8 @@ class SearchRequestSerializer(serializers.Serializer):
     project_event = serializers.IntegerField(allow_null=True, required=False)
     project_state = serializers.ChoiceField(
         choices=STATE_CHOICES, allow_null=True, required=False)
+    project_tags = serializers.ListField(
+        child=serializers.IntegerField(), allow_null=True, required=False)
 
 
 class SearchResponseSerializer(serializers.Serializer):

--- a/backend/api/views/search.py
+++ b/backend/api/views/search.py
@@ -64,7 +64,8 @@ class SearchGenericAPIView(generics.GenericAPIView):
             query_following = list(map(lambda following: following.to_user,
                                        Following.objects.
                                        filter(from_user=request.user)))
-
+    
+        # Query the database for each keyword
         for keyword in keywords:
             if search_events:
                 q = Q(title__icontains=keyword) | Q(
@@ -100,6 +101,8 @@ class SearchGenericAPIView(generics.GenericAPIView):
                     q &= Q(event__id=req_data["project_event"])
                 if "project_state" in req_data:
                     q &= Q(state=req_data["project_state"])
+                if "tags" in req_data:
+                    q &= Q(tags__in=req_data["tags"])
 
                 q &= (Q(name__icontains=keyword) |
                       Q(description__icontains=keyword) |
@@ -176,6 +179,7 @@ class SearchGenericAPIView(generics.GenericAPIView):
 
                     query_private_profiles += Profile.objects.filter(q)
 
+        # Fill the Response
         if search_events:
             query_events = list(set(query_events))
 

--- a/backend/api/views/search.py
+++ b/backend/api/views/search.py
@@ -181,7 +181,6 @@ class SearchGenericAPIView(generics.GenericAPIView):
                     if isGuest:
                         q = Q(is_public=False)
                     else:
-                        
                         q = (Q(is_public=False) & ~Q(
                             owner__in=query_following))
                     q &= (Q(name__icontains=keyword) |


### PR DESCRIPTION
- Added "project_tags" filter to search, it accepts list of tag ids and it will filter project objects.
- Adjusted public_project_filters & public_profile_filters according to their private serializers.
- Registered Tag object to be used in admin panel.