### PR TITLE
[Backend] Implemented login with email

### DIFF
--- a/backend/api/serializers/auth.py
+++ b/backend/api/serializers/auth.py
@@ -1,6 +1,7 @@
 from django.contrib.auth.models import User
 from api.models.profile import Profile
 from rest_framework import serializers
+from django.utils.translation import gettext_lazy as _
 
 
 class RegisterSerializer(serializers.Serializer):
@@ -22,6 +23,62 @@ class RegisterSerializer(serializers.Serializer):
                           last_name=data['last_name'])
         profile.save()
         return user
-# class LoginSerializer(serializers.Serializer):
-#     username = serializers.CharField()
-#     password = serializers.CharField()
+
+
+class AuthTokenSerializer(serializers.Serializer):
+    username = serializers.CharField(
+        label=_("Username"),
+        write_only=True
+    )
+    password = serializers.CharField(
+        label=_("Password"),
+        style={'input_type': 'password'},
+        trim_whitespace=False,
+        write_only=True
+    )
+    token = serializers.CharField(
+        label=_("Token"),
+        read_only=True
+    )
+
+    def authenticate_email(self, email: str, password: str):
+        """ Authenticate a user based on username. """
+        try:
+            user = User.objects.get(email=email)
+            if user.check_password(password):
+                return user
+        except Exception:
+            return None
+
+    def authenticate_username(self, username: str, password: str):
+        """ Authenticate a user based on email address. """
+        try:
+            user = User.objects.get(username=username)
+            if user.check_password(password):
+                return user
+        except Exception:
+            return None
+
+    def validate(self, attrs):
+        username = attrs.get('username')
+        password = attrs.get('password')
+
+        if username and password:
+            user = self.authenticate_username(
+                username=username, password=password)
+            if not user:
+                user = self.authenticate_email(
+                    email=username, password=password)
+
+            # The authenticate call simply returns None for is_active=False
+            # users. (Assuming the default ModelBackend authentication
+            # backend.)
+            if not user:
+                msg = _('Unable to log in with provided credentials.')
+                raise serializers.ValidationError(msg, code='authorization')
+        else:
+            msg = _('Must include "username" and "password".')
+            raise serializers.ValidationError(msg, code='authorization')
+
+        attrs['user'] = user
+        return attrs

--- a/backend/api/views/auth.py
+++ b/backend/api/views/auth.py
@@ -6,7 +6,7 @@ from django.contrib.auth import logout
 from rest_framework import generics
 from rest_framework import parsers, renderers
 from rest_framework.authtoken.models import Token
-from rest_framework.authtoken.serializers import AuthTokenSerializer
+from api.serializers.auth import AuthTokenSerializer
 from rest_framework.compat import coreapi, coreschema
 from rest_framework.schemas import ManualSchema
 from rest_framework.schemas import coreapi as coreapi_schema


### PR DESCRIPTION
- Users can login either with username or email.
- The field for email or username is still "username" in the auth endpoint so other teams won't have to change anything