### PR TITLE
Added collaborator recommendation

### DIFF
--- a/backend/api/views/user.py
+++ b/backend/api/views/user.py
@@ -120,16 +120,9 @@ class UserViewSet(viewsets.ReadOnlyModelViewSet):
         for invite in invited_users:
             user_score.pop(invite.to_user.id, None)
 
-        top_ids = []
-
-        if len(user_score) >= 10:
-            top_ids = [f for f in sorted(user_score,
-                                         key=user_score.get,
-                                         reverse=True)[:10]]
-        else:
-            top_ids = [f for f in sorted(user_score,
-                                         key=user_score.get,
-                                         reverse=True)]
+        top_ids = [i for i in sorted(user_score,
+                                     key=user_score.get,
+                                     reverse=True)]
 
         preserved = Case(*[When(id=pk, then=pos)
                            for pos, pk in enumerate(top_ids)])

--- a/backend/backend/tests/test_collaborator_recommendation.py
+++ b/backend/backend/tests/test_collaborator_recommendation.py
@@ -1,0 +1,36 @@
+from django.contrib.auth.models import User
+from rest_framework import status
+from rest_framework.test import APITestCase
+from api.models.project import Project
+from api.models.profile import Profile
+
+
+class CollaboratorRecommendationTests(APITestCase):
+    """
+    Tests for the collaborators.
+    """
+
+    def setUp(self):
+        self.owner = User.objects.create_user(
+            username='jane_doe', email='jane_doe@…', password='1234_secret')
+        self.expected_user = User.objects.create_user(
+            username='mehmet', email='mehmet@…', password='1234_secret')
+        self.expected_profile = Profile.objects.create(
+            expertise='Machine Learning', owner=self.expected_user)
+        self.unexpected_user = User.objects.create_user(
+            username='mahmut', email='mahmut@…', password='1234_secret')
+        self.unexpected_profile = Profile.objects.create(
+            expertise='Psychology', owner=self.unexpected_user)
+        self.project = Project.objects.create(
+            name='Academic Project',
+            description='This is an academic project.',
+            requirements='Machine Learning, NLP',
+            state='open for collaborators',
+            owner=self.owner, due_date="2020-12-15")
+
+    def test_can_get_recommendation(self):
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.get('/api/users/' +
+                                   'get_collaborator_recommendation/' +
+                                   '?project_id=1')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)


### PR DESCRIPTION
Owner of the project can now get a recommendation for collaborators. An example API call would be like the following:

api/users/get_collaborator_recommendation/?project_id=1

This endpoint will return at most 10 users. If the number of users in the database who are not a member of the specified project is smaller than 10, it can return less than 10 users. All users are sorted according to the following formula:

(1 + number of requirements matching with user expertise) * ( 1 + (user rating/10)) * (if project owner follows the user 1.2 else 1)