### PR TITLE
Added project recommendations

### DIFF
--- a/backend/api/utils.py
+++ b/backend/api/utils.py
@@ -2,6 +2,7 @@ from api.models.following import Following, FollowRequest
 from api.models.project import Project
 from api.models.rating import Rating
 from api.models.publication import Publication
+from django.db.models import Avg
 
 
 def get_is_following(this_user, accessed_user):
@@ -128,3 +129,9 @@ def get_count_of_publications(this_user):
         Returns length of publications of user
     """
     return Publication.objects.filter(owner=this_user.id).count()
+
+
+def get_user_rating(user_id):
+    ratings = Rating.objects.filter(to_user=user_id)
+    rating = ratings.aggregate(Avg('rating'))
+    return rating['rating__avg']

--- a/backend/api/views/project.py
+++ b/backend/api/views/project.py
@@ -8,6 +8,21 @@ from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.response import Response
 from notifications.signals import notify
 from api.models.project import Project
+from rest_framework.decorators import action
+from api.models.profile import Profile
+from api.models.following import Following
+from api.models.collaboration_request import CollaborationRequest
+import math
+import re
+from drf_yasg import openapi
+from drf_yasg.utils import swagger_auto_schema
+from django.db.models import Case, When
+from api.utils import get_user_rating
+
+user_param = openapi.Parameter(
+    'user_id', openapi.IN_QUERY,
+    description="User id to get recommendations",
+    type=openapi.TYPE_INTEGER)
 
 
 class ProjectViewSet(viewsets.ModelViewSet):
@@ -66,3 +81,85 @@ class ProjectViewSet(viewsets.ModelViewSet):
         if self.action == 'destroy':
             pass
         return response
+
+    @swagger_auto_schema(
+        method='get', manual_parameters=[user_param]
+    )
+    @action(detail=False, methods=['GET'],
+            name='get_project_recommendation',
+            serializer_class=None)
+    def get_project_recommendation(self, request):
+        user_id = request.GET.get('user_id', None)
+        profile = Profile.objects.get(owner_id=user_id)
+        exps = []
+        if profile.expertise:
+            exps = re.split('; |, |\n', profile.expertise)
+            exps = [r.strip() for r in exps]
+
+        """
+            value of the dictionary items will be a list of length 3:
+            [rating_score, requirement_score, following_score]
+
+            The end score calculation will be the following:
+            rating_score*requirement_score*following_score
+
+            Base value for rating_score is 1, rating/10 is added to this value.
+            If someone has no rating it is treated as a rating of 5.
+            This is the rating of the owner of the project.
+
+            Default score for requirement is 1 and is incremented by 1
+            with each match with expertise.
+
+            Following_score is 1.2 for the pprojects that contain members
+            that the user follows, 1 otherwise.
+        """
+
+        project_score = {}
+
+        followed_users = Following.objects.filter(from_user=user_id)
+        projects = Project.objects.filter(state="open for collaborators")
+        for project in projects:
+            rating = get_user_rating(project.owner_id)
+            scaled_rating = rating/10.0 if rating else 0.5
+            project_score[project.id] = [1 + scaled_rating, 1, 1]
+
+            members = project.members.all()
+            members = [member.id for member in members]
+            for followed in followed_users:
+                if followed.to_user.id in members:
+                    project_score[project.id][2] = 1.2
+                    break
+
+        for keyword in exps:
+            projects = Project.objects.filter(
+                requirements__icontains=keyword,
+                state="open for collaborators")
+            for project in projects:
+                project_score[project.id][1] += 1
+
+        for project_id, scores in project_score.items():
+            project_score[project_id] = math.prod(scores)
+
+        member_projects = Project.objects.filter(
+            members__id__in=[user_id])
+        # pop the projects that the user is a member of out of the list
+        for m_project in member_projects:
+            project_score.pop(m_project.id, None)
+
+        req_projects = CollaborationRequest.objects.filter(
+            from_user=user_id)
+        # pop the requested projects out of the list
+        for req in req_projects:
+            project_score.pop(req.to_project.id, None)
+
+        top_ids = [i for i in sorted(project_score,
+                                     key=project_score.get,
+                                     reverse=True)]
+
+        preserved = Case(*[When(id=pk, then=pos)
+                           for pos, pk in enumerate(top_ids)])
+        projects = Project.objects.filter(id__in=top_ids).order_by(preserved)
+        serializer_context = {'request': request}
+        serializer = ProjectGETPublicSerializer(
+            projects, many=True, context=serializer_context)
+        return Response(serializer.data)

--- a/backend/api/views/user.py
+++ b/backend/api/views/user.py
@@ -5,16 +5,14 @@ from api.serializers.user import UserFullSerializer
 from api.serializers.user import UserBasicSerializer
 from api.serializers.user import UserPrivateSerializer
 from rest_framework.response import Response
-from api.utils import get_is_following
+from api.utils import get_is_following, get_user_rating
 from rest_framework.decorators import action
 from django.shortcuts import get_object_or_404
 from api.models.project import Project
 from api.models.following import Following
-from api.models.rating import Rating
 from api.models.collaboration_invite import CollaborationInvite
 import math
 import re
-from django.db.models import Avg
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from django.db.models import Case, When
@@ -84,7 +82,7 @@ class UserViewSet(viewsets.ReadOnlyModelViewSet):
             Default score for expertise is 1 and is incremented by 1
             with each match with requirements.
 
-            Following_score is 1.1 for the users that the owner follows,
+            Following_score is 1.2 for the users that the owner follows,
             1 otherwise.
         """
 
@@ -92,7 +90,7 @@ class UserViewSet(viewsets.ReadOnlyModelViewSet):
 
         profiles = Profile.objects.all()
         for profile in profiles:
-            rating = get_rating(profile.owner_id)
+            rating = get_user_rating(profile.owner_id)
             scaled_rating = rating/10.0 if rating else 0.5
             user_score[profile.owner_id] = [1 + scaled_rating, 1, 1]
 
@@ -131,22 +129,3 @@ class UserViewSet(viewsets.ReadOnlyModelViewSet):
         serializer = UserBasicSerializer(
             users, many=True, context=serializer_context)
         return Response(serializer.data)
-
-
-def get_is_following_from_id(this_user_id, accessed_user_id):
-    """
-        Returns True if "this_user" follows "accessed_user"
-    """
-    if not this_user_id:
-        is_following = False
-    else:
-        is_following = Following.objects.filter(
-            from_user__id=this_user_id,
-            to_user__id=accessed_user_id).exists()
-    return is_following
-
-
-def get_rating(user_id):
-    ratings = Rating.objects.filter(to_user=user_id)
-    rating = ratings.aggregate(Avg('rating'))
-    return rating['rating__avg']


### PR DESCRIPTION
Users can now get recommendations for projects. An example API call would be like the following:

api/projects/get_project_recommendation/?user_id=1

This endpoint will return all projects. All projects are sorted according to the following formula:

(1 + number of requirements matching with user expertise) * ( 1 + (project owner rating/10)) * (if user follows any of the project members 1.2 else 1)