### PR TITLE
[Android] Bug resolved - Change the visibility of the members back to its original state

### DIFF
--- a/android/app/src/main/res/layout/fragment_project_detail.xml
+++ b/android/app/src/main/res/layout/fragment_project_detail.xml
@@ -457,6 +457,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:orientation="vertical"
+                android:visibility="gone"
                 tools:visibility="gone">
 
 


### PR DESCRIPTION
While debugging some of the settings were forgotten changed. Now it is solved.