### PR TITLE
Reenable email verification

### DIFF
--- a/backend/api/views/auth.py
+++ b/backend/api/views/auth.py
@@ -18,10 +18,8 @@ from django.template.loader import render_to_string
 from django_email_verification.views import verify
 from django.urls import get_resolver
 from django.contrib.auth.tokens import default_token_generator
-# from django_email_verification.Confirm import sendConfirm
-# validateAndGetField
 
-# from api.views.feed import follow_admin
+from api.views.feed import follow_admin
 
 
 class RegisterGenericAPIView(generics.GenericAPIView):
@@ -55,15 +53,8 @@ class RegisterGenericAPIView(generics.GenericAPIView):
         serializer.is_valid(raise_exception=True)
         user = serializer.save()
         self.__send_verification(user)
-        # sendConfirm(user)
 
-        # For testing purposes. Normally, user can't log in if the system
-        # fails to send an email.
-        # active_field = validateAndGetField('EMAIL_ACTIVE_FIELD')
-        # setattr(user, active_field, True)
-        # user.save()
-
-        # follow_admin(serializer.data['username'])
+        follow_admin(serializer.data['username'])
 
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -174,20 +174,7 @@ EMAIL_HOST = 'smtp.gmail.com'
 EMAIL_PORT = 587
 EMAIL_USE_TLS = True
 EMAIL_HOST_USER = 'bounswe2020group3@gmail.com'
-# os.environ.get('EMAIL_HOST_PASSWORD', '')
-EMAIL_HOST_PASSWORD = 'Group3isthebest'
-
-# For email verification
-EMAIL_ACTIVE_FIELD = 'is_active'
-EMAIL_SERVER = 'smtp.gmail.com'
-EMAIL_ADDRESS = 'bounswe2020group3@gmail.com'
-EMAIL_FROM_ADDRESS = 'noreply@bounswe2020group3.com'
-EMAIL_PASSWORD = 'Group3isthebest'  # os.environ.get('EMAIL_HOST_PASSWORD', '')
-EMAIL_MAIL_SUBJECT = 'Confirm your email'
-EMAIL_MAIL_HTML = 'verification_body.html'
-EMAIL_MAIL_PLAIN = 'verification_body.txt'
-EMAIL_PAGE_TEMPLATE = 'verification_confirm.html'
-EMAIL_PAGE_DOMAIN = 'https://paperlayer-backend.azurewebsites.net'
+EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_HOST_PASSWORD', '')
 
 django_heroku.settings(locals())
 


### PR DESCRIPTION
- Created my own verification email send method.
- Currently, new users are is_active=True by default. This will change when we are sure that system can send emails.
- Previous one was not working when deployed.

